### PR TITLE
Fix revalidation on jobs pages. Fix job creation query

### DIFF
--- a/pages/api/jobs/create.js
+++ b/pages/api/jobs/create.js
@@ -34,8 +34,17 @@ class JobCreationRoute extends ApiRoute {
         throw error;
       }
 
-      const { closingDate, title, description, paid, duration, departments, weeklyHours, credit } =
-        value;
+      const {
+        closingDate,
+        title,
+        description,
+        paid,
+        duration,
+        departments,
+        weeklyHours,
+        credit,
+        location,
+      } = value;
 
       // TODO: what if closingDate is not passed in request body
       let closeDate = null;
@@ -57,11 +66,12 @@ class JobCreationRoute extends ApiRoute {
           departments,
           weeklyHours,
           credit,
+          location,
         },
       });
 
       await res.revalidate(`/job/${result.id}`);
-      await res.revalidate('');
+      await res.revalidate('/');
 
       res.status(200).json(result);
     } catch (e) {

--- a/pages/job/[jobId].jsx
+++ b/pages/job/[jobId].jsx
@@ -152,7 +152,7 @@ export async function getStaticPaths() {
     params: { jobId: job.id.toString(10) },
   }));
 
-  return { paths, fallback: false };
+  return { paths, fallback: 'blocking' };
 }
 
 export default Job;


### PR DESCRIPTION
**Description**

Have job creation route revalidate home page and the new job's page. The old fallback option didn't allow the jobs pages to be rebuilt or created during job creation. Fix job creation query not inserting the location.