### PR TITLE
Add sans-serif as fallback font

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -2,7 +2,7 @@ import '../styles/globals.css';
 import { SessionProvider } from 'next-auth/react';
 import { Kumbh_Sans } from 'next/font/google';
 
-const kumbhSans = Kumbh_Sans({ subsets: ['latin'] });
+const kumbhSans = Kumbh_Sans({ subsets: ['latin'], fallback: ['sans-serif'] });
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }) {
   return (


### PR DESCRIPTION
**Description**

Add sans-serif as fallback font. This was mostly because of Firefox not showing the font on <option> elements https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#styling_with_css