### PR TITLE
Use global prisma for static page queries

### DIFF
--- a/pages/job/[jobId].jsx
+++ b/pages/job/[jobId].jsx
@@ -1,5 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-const prisma = new PrismaClient();
+import prisma from '@lib/prisma';
 
 function Job(props) {
   return (

--- a/pages/student/profile/[studentSlug].jsx
+++ b/pages/student/profile/[studentSlug].jsx
@@ -1,7 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { useEffect, useState } from 'react';
 import { UUIDV4Validator } from '@lib/validators';
-const prisma = new PrismaClient();
+import prisma from '@lib/prisma';
 
 const pronounsMapping = {
   NOT_LISTED: 'Not Listed',
@@ -113,7 +112,6 @@ export async function getStaticProps(context) {
 
   const { error } = UUIDV4Validator.validate(profileID);
   if (error) {
-    console.log({ error, slug: profileID });
     return { notFound: true };
   }
 


### PR DESCRIPTION
**Description**

Use global prisma for static page queries. It'll hopefully lessen this supabase/prisma query error: `message: "prepared statement \"s0\" already exists"`
