### PR TITLE
Add database directUrl

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 enum Department {


### PR DESCRIPTION
**Description**

Add database directUrl. This will hopefully lessen this supabase/prisma query error: `message: "prepared statement \"s0\" already exists"`